### PR TITLE
Fix background color under Dark Reader

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -3,7 +3,7 @@
   padding: 0;
 }
 
-body {
+html {
 	font-family: 'Montserrat', sans-serif;
 	background-color: #C8CFB9;
 }


### PR DESCRIPTION
Small fix that makes [Dark Reader](https://darkreader.org/) display the web in dark theme properly